### PR TITLE
Allow 1 Tick of Lag to Update the Timer Logicate Renderer

### DIFF
--- a/src/main/java/me/luligabi/logicates/common/block/logicate/inputless/timer/TimerLogicateBlockEntity.java
+++ b/src/main/java/me/luligabi/logicates/common/block/logicate/inputless/timer/TimerLogicateBlockEntity.java
@@ -70,7 +70,7 @@ public class TimerLogicateBlockEntity extends ClientSyncedBlockEntity implements
             blockEntity.ticks = 0;
         }
 
-        if (blockEntity.ticks == 1) {
+        if(blockEntity.ticks == 1) {
             world.setBlockState(pos, state.with(LogicateBlock.POWERED, false), 1);
         }
         blockEntity.sync();

--- a/src/main/java/me/luligabi/logicates/common/block/logicate/inputless/timer/TimerLogicateBlockEntity.java
+++ b/src/main/java/me/luligabi/logicates/common/block/logicate/inputless/timer/TimerLogicateBlockEntity.java
@@ -63,12 +63,15 @@ public class TimerLogicateBlockEntity extends ClientSyncedBlockEntity implements
             blockEntity.ticks++;
         } else {
             world.setBlockState(pos, state.with(LogicateBlock.POWERED, true), 1);
-            world.setBlockState(pos, state.with(LogicateBlock.POWERED, false), 1);
             if(!blockEntity.mute) {
                 world.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.UI_BUTTON_CLICK,
                         SoundCategory.BLOCKS, 0.5F, 1F, pos.asLong());
             }
             blockEntity.ticks = 0;
+        }
+
+        if (blockEntity.ticks == 1) {
+            world.setBlockState(pos, state.with(LogicateBlock.POWERED, false), 1);
         }
         blockEntity.sync();
     }


### PR DESCRIPTION
Closes #1 

The timer is normally set to power on and off the block state on a single tick. This means that render updates do not happen to the block unless directly forced (like in the case of neighbor updates). Additionally, while Minecraft can handle multiple block changes to the same position in a single tick, it is generally advised to allow one tick of downtime to avoid any client desyncs (I should note that some systems are updated every 2-3 ticks, so those scenarios would cause unseen behavior quite often). To address both of these issues, the timer outputs a signal for a single tick, allowing the block to rerender in time.